### PR TITLE
Removed trim() in searchbar

### DIFF
--- a/seenema-frontend/src/Homepage/js/SearchBar.js
+++ b/seenema-frontend/src/Homepage/js/SearchBar.js
@@ -38,7 +38,7 @@ const SearchBar = ({onSearch, isGenre, genreId}) => {
     };
 
     const handleSearchChange = (e) => {
-        setSearchValue(e.target.value.trim())
+        setSearchValue(e.target.value)
         if (e.target.value.trim() === "") {
             const value = "";
             onSearch(value);


### PR DESCRIPTION
User was not able to search with space in the search bar, but now it can.